### PR TITLE
feat: add smooth scrolling + github link

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout ({ children }) {
   return (
-    <html lang="ptbr">
+    <html className="scroll-smooth" lang="ptbr">
       <body>
         {children}
         <Toaster />

--- a/apps/web/domains/landing-page/Values.tsx
+++ b/apps/web/domains/landing-page/Values.tsx
@@ -47,7 +47,7 @@ export const Values = () => (
                   disponível através do GitHub. Se você simpatiza com a ideia de
                   adoção do modelo de trabalho remoto,{" "}
                   <a
-                    className="text-gray-600 font-medium"
+                    className="font-medium"
                     target="_blank"
                     href="https://github.com/ocodista/trampar-de-casa"
                   >

--- a/apps/web/domains/landing-page/Values.tsx
+++ b/apps/web/domains/landing-page/Values.tsx
@@ -45,8 +45,14 @@ export const Values = () => (
                 <p className="text-gray-600 font-medium">
                   Todo o código utilizado neste projeto é público e está
                   disponível através do GitHub. Se você simpatiza com a ideia de
-                  adoção do modelo de trabalho remoto, contribua com nosso
-                  projeto!
+                  adoção do modelo de trabalho remoto,{" "}
+                  <a
+                    className="text-gray-600 font-medium"
+                    target="_blank"
+                    href="https://github.com/ocodista/trampar-de-casa"
+                  >
+                    contribua com nosso projeto!
+                  </a>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
adds smooth scrolling for cleaner landing page navigation.

this way, by clicking the header anchors, users don't snap straight into the sections. there's a smooth animation to the scroll.

i also added a github link to the relevant section.