### PR TITLE
cache subscriber count with server components

### DIFF
--- a/apps/web/app/api/subscribers/route.ts
+++ b/apps/web/app/api/subscribers/route.ts
@@ -1,9 +1,8 @@
-import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { StatusCodes } from 'http-status-codes'
-import { getSupabaseClient } from '../../db/getSupabaseClient'
-import { Entities, SupabaseCodes } from 'shared/src/enums'
+import { NextResponse } from 'next/server'
 import { sendConfirmationEmail } from 'shared/src/email'
+import { Entities, SupabaseCodes } from 'shared/src/enums'
+import { getSupabaseClient } from '../../db/getSupabaseClient'
 
 interface EmailRequest {
   email: string
@@ -44,19 +43,5 @@ export async function POST(request: Request) {
 
   // eslint-disable-next-line no-console
   console.error(error)
-  return new NextResponse(null, { status: StatusCodes.INTERNAL_SERVER_ERROR })
-}
-
-export async function GET() {
-  const supabase = createClient(
-    process.env['SUPABASE_URL'],
-    process.env['SUPABASE_SERVICE_ROLE']
-  )
-
-  const { count, error } = await supabase
-    .from(Entities.Subcribers)
-    .select('*', { count: 'exact' })
-  if (!error) return NextResponse.json(count)
-
   return new NextResponse(null, { status: StatusCodes.INTERNAL_SERVER_ERROR })
 }

--- a/apps/web/app/components/ui/ScrollToTopButton.tsx
+++ b/apps/web/app/components/ui/ScrollToTopButton.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
-import { ChevronUpIcon } from 'lucide-react'
+'use client'
 import clsx from 'clsx'
+import { ChevronUpIcon } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 export default function ScrollToTopButton() {
   const [backToTop, setBackToTop] = useState(false)

--- a/apps/web/app/hooks/use-toast.ts
+++ b/apps/web/app/hooks/use-toast.ts
@@ -1,3 +1,4 @@
+'use client'
 // Inspired by react-hot-toast library
 import * as React from 'react'
 

--- a/apps/web/app/landing-page/FrontinCoupon.tsx
+++ b/apps/web/app/landing-page/FrontinCoupon.tsx
@@ -1,0 +1,39 @@
+'use client'
+import { Check, Copy } from 'lucide-react'
+import { useState } from 'react'
+
+export function FrontinCoupon() {
+  const [isCopied, setIsCopied] = useState(false)
+  return (
+    <div className="text-center">
+      <div
+        className="px-4 py-2 max-md:py-3 bg-indigo-600 text-indigo-100 leading-none flex items-center justify-center gap-1 max-md:flex-col max-md:gap-2"
+        role="alert"
+      >
+        <span className="font-medium mr-2 leading-tight max-md:text-lg">
+          <span className="font-bold">20% de desconto</span> no maior evento de{' '}
+          <i>Front-end</i> da América Latina.
+        </span>
+
+        <span
+          className="px-3 py-1 mr-[6px] flex items-center gap-2 rounded-full uppercase text-xs max-md:text-sm font-bold max-md:font-semibold bg-indigo-500 hover:bg-indigo-700 transition-colors cursor-pointer"
+          onClick={async () => {
+            await navigator.clipboard
+              .writeText('TRAMPARDECASA')
+              .then(() => setIsCopied(true))
+
+            setTimeout(() => {
+              setIsCopied(false)
+              window.open(
+                'https://www.eventbrite.com.br/e/frontin-sampa-2023-code-in-the-dark-tickets-574922567877',
+                '_blank'
+              )
+            }, 300)
+          }}
+        >
+          TRAMPARDECASA {isCopied ? <Check size={14} /> : <Copy size={14} />}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/landing-page/Hero.tsx
+++ b/apps/web/app/landing-page/Hero.tsx
@@ -1,189 +1,25 @@
-'use client'
 import Image from 'next/image'
-import { useState } from 'react'
-import { useQuery } from 'react-query'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { ErrorMessage } from '@hookform/error-message'
-import { z } from 'zod'
-import { StatusCodes } from 'http-status-codes'
-import { ApiRoutes } from 'shared/src/enums'
-import { useToast } from '../hooks/use-toast'
-import { useLoadingContext } from '../contexts/LoadingContext'
 import { PartnerCompanies } from '../components/PartnerCompanies'
-import { Copy, Check } from 'lucide-react'
-import fireworks from '../utils/confetti'
-
-const validationSchema = z.object({
-  email: z.string().email('Insira um e-mail válido!'),
-})
-
-type ValidationSchema = z.infer<typeof validationSchema>
+import { FrontinCoupon } from './FrontinCoupon'
+import { SubscriberForm } from './SubscriberForm'
+import SubscribersCount from './SubscribersCount'
 
 export const Hero = () => {
-  const { isLoading, withLoading } = useLoadingContext()
-  const [isCopied, setIsCopied] = useState(false)
-
-  const methods = useForm<ValidationSchema>({
-    resolver: zodResolver(validationSchema),
-    mode: 'onTouched',
-  })
-
-  const {
-    register,
-    getValues,
-    formState: { isValid, errors },
-  } = methods
-
-  const { toast } = useToast()
-
-  const getSubscribersCount = async (): Promise<number | null> => {
-    const response = await fetch(ApiRoutes.Subscribers)
-    if (!response?.ok) return null
-    const count = await response.json()
-    return count
-  }
-  const { data: subscribersCount } = useQuery<number>(
-    'subscribersCountQuery',
-    async () => await getSubscribersCount()
-  )
-
-  const saveSubscriber = async () => {
-    const email = getValues().email
-    try {
-      const response = await fetch(ApiRoutes.Subscribers, {
-        body: JSON.stringify({ email }),
-        method: 'POST',
-      })
-
-      if (response.ok) {
-        fireworks()
-        toast({
-          title: 'Tudo certo 🥳',
-          description: 'Enviamos uma confirmação para o seu e-mail!',
-        })
-        return
-      }
-
-      if (response.status === StatusCodes.CONFLICT) {
-        toast({
-          title: 'Algo deu errado 🥶',
-          variant: 'destructive',
-          description: await response.text(),
-        })
-        return
-      }
-
-      throw new Error(response.statusText)
-    } catch (err) {
-      toast({
-        title: 'Algo deu errado 🥶',
-        variant: 'destructive',
-        description:
-          'Não conseguimos adicionar seu e-mail, tente novamente mais tarde.',
-      })
-    }
-
-    return false
-  }
-
   return (
     <>
-      <div className="text-center">
-        <div
-          className="px-4 py-2 max-md:py-3 bg-indigo-600 text-indigo-100 leading-none flex items-center justify-center gap-1 max-md:flex-col max-md:gap-2"
-          role="alert"
-        >
-          <span className="font-medium mr-2 leading-tight max-md:text-lg">
-            <span className="font-bold">20% de desconto</span> no maior evento
-            de <i>Front-end</i> da América Latina.
-          </span>
-
-          <span
-            className="px-3 py-1 mr-[6px] flex items-center gap-2 rounded-full uppercase text-xs max-md:text-sm font-bold max-md:font-semibold bg-indigo-500 hover:bg-indigo-700 transition-colors cursor-pointer"
-            onClick={async () => {
-              await navigator.clipboard
-                .writeText('TRAMPARDECASA')
-                .then(() => setIsCopied(true))
-
-              setTimeout(() => {
-                setIsCopied(false)
-                window.open(
-                  'https://www.eventbrite.com.br/e/frontin-sampa-2023-code-in-the-dark-tickets-574922567877',
-                  '_blank'
-                )
-              }, 300)
-            }}
-          >
-            TRAMPARDECASA {isCopied ? <Check size={14} /> : <Copy size={14} />}
-          </span>
-        </div>
-      </div>
-
+      <FrontinCoupon />
       <div className="pt-6 pb-28">
         <div className="container mx-auto">
           <div className="flex flex-wrap items-center -m-8">
             <div className="w-full lg:w-1/2 p-8 lg:pr-0">
-              {subscribersCount ? (
-                <div className="inline-block mb-6 px-2 py-1 font-semibold bg-green-100 rounded-md roll-animation">
-                  <div className="flex flex-wrap items-center -m-1">
-                    <div className="w-auto py-1 px-2">
-                      <span className="text-sm">
-                        👋 Junte-se a {subscribersCount.toLocaleString()}{' '}
-                        inscritos!
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <div className="h-[32px] mb-6"></div>
-              )}
+              <SubscribersCount />
               <h1 className="mb-6 text-6xl md:text-8xl lg:text-10xl font-bold font-heading leading-none max-xs:text-4xl">
                 Vagas remotas no seu e-mail
               </h1>
               <p className="mb-9 text-lg md:text-xl text-gray-900 font-medium max-xl:max-w-sm">
                 Levamos as melhores oportunidades de trampo até você.
               </p>
-              <div className="p-1.5 xl:pl-7 inline-block w-full border-2 border-black rounded-xl focus-within:ring focus-within:ring-indigo-300 -my-2.5 lg:-m-2.5">
-                <form
-                  onSubmit={async (e) => {
-                    e.preventDefault()
-                    await withLoading(saveSubscriber)
-                  }}
-                >
-                  <div className="flex flex-wrap items-center">
-                    <div className="w-full xl:flex-1">
-                      <input
-                        className="p-3 xl:p-0 xl:pr-7 w-full text-gray-600 placeholder-gray-600 outline-none"
-                        id="email"
-                        type="email"
-                        disabled={isLoading}
-                        placeholder="Digite seu melhor e-mail"
-                        {...register('email')}
-                      />
-                    </div>
-                    <div className="w-full xl:w-auto">
-                      <div className="block">
-                        <button
-                          type="submit"
-                          disabled={!isValid || isLoading}
-                          className="py-4 px-7 w-full text-white font-semibold rounded-xl focus:ring focus:ring-indigo-300 bg-indigo-600 hover:bg-indigo-700 transition ease-in-out duration-200 pointer 
-                              disabled:opacity-50 cursor-pointer disabled:cursor-default"
-                        >
-                          Quero participar
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </form>
-              </div>
-              <section className="text-red-600 my-4 mb-16 min-h-[30px] text-sm">
-                <ErrorMessage
-                  name="email"
-                  errors={errors}
-                  render={({ message }) => <p>{message}</p>}
-                />
-              </section>
+              <SubscriberForm />
               <PartnerCompanies />
             </div>
             <div className="w-full lg:w-1/2 p-8">

--- a/apps/web/app/landing-page/SubscriberForm.tsx
+++ b/apps/web/app/landing-page/SubscriberForm.tsx
@@ -1,0 +1,115 @@
+'use client'
+import { ErrorMessage } from '@hookform/error-message'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useLoadingContext } from 'app/contexts/LoadingContext'
+import { useToast } from 'app/hooks/use-toast'
+import { StatusCodes } from 'http-status-codes'
+import { useForm } from 'react-hook-form'
+import { ApiRoutes } from 'shared/src/enums/apiRoutes'
+import { z } from 'zod'
+import fireworks from '../utils/confetti'
+
+const validationSchema = z.object({
+  email: z.string().email('Insira um e-mail válido!'),
+})
+type ValidationSchema = z.infer<typeof validationSchema>
+
+export function SubscriberForm() {
+  const { isLoading, withLoading } = useLoadingContext()
+  const { toast } = useToast()
+
+  const saveSubscriber = async () => {
+    const email = getValues().email
+    try {
+      const response = await fetch(ApiRoutes.Subscribers, {
+        body: JSON.stringify({ email }),
+        method: 'POST',
+      })
+
+      if (response.ok) {
+        fireworks()
+        toast({
+          title: 'Tudo certo 🥳',
+          description: 'Enviamos uma confirmação para o seu e-mail!',
+        })
+        return
+      }
+
+      if (response.status === StatusCodes.CONFLICT) {
+        toast({
+          title: 'Algo deu errado 🥶',
+          variant: 'destructive',
+          description: await response.text(),
+        })
+        return
+      }
+
+      throw new Error(response.statusText)
+    } catch (err) {
+      toast({
+        title: 'Algo deu errado 🥶',
+        variant: 'destructive',
+        description:
+          'Não conseguimos adicionar seu e-mail, tente novamente mais tarde.',
+      })
+    }
+
+    return false
+  }
+
+  const methods = useForm<ValidationSchema>({
+    resolver: zodResolver(validationSchema),
+    mode: 'onTouched',
+  })
+
+  const {
+    register,
+    getValues,
+    formState: { isValid, errors },
+  } = methods
+
+  return (
+    <>
+      <div className="p-1.5 xl:pl-7 inline-block w-full border-2 border-black rounded-xl focus-within:ring focus-within:ring-indigo-300 -my-2.5 lg:-m-2.5">
+        <form
+          onSubmit={async (e) => {
+            e.preventDefault()
+            await withLoading(saveSubscriber)
+          }}
+        >
+          <div className="flex flex-wrap items-center">
+            <div className="w-full xl:flex-1">
+              <input
+                className="p-3 xl:p-0 xl:pr-7 w-full text-gray-600 placeholder-gray-600 outline-none"
+                id="email"
+                type="email"
+                disabled={isLoading}
+                placeholder="Digite seu melhor e-mail"
+                {...register('email')}
+              />
+            </div>
+            <div className="w-full xl:w-auto">
+              <div className="block">
+                <button
+                  type="submit"
+                  disabled={!isValid || isLoading}
+                  className="py-4 px-7 w-full text-white font-semibold rounded-xl focus:ring focus:ring-indigo-300 bg-indigo-600 hover:bg-indigo-700 transition ease-in-out duration-200 pointer 
+                      disabled:opacity-50 cursor-pointer disabled:cursor-default"
+                >
+                  Quero participar
+                </button>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+      <section className="text-red-600 my-4 mb-16 min-h-[30px] text-sm">
+        <ErrorMessage
+          name="email"
+          errors={errors}
+          render={({ message }) => <p>{message}</p>}
+        />
+      </section>
+    </>
+  )
+}

--- a/apps/web/app/landing-page/SubscribersCount.tsx
+++ b/apps/web/app/landing-page/SubscribersCount.tsx
@@ -1,0 +1,36 @@
+'use server'
+import { createClient } from '@supabase/supabase-js'
+import { Entities } from 'shared'
+
+const getSubscriberCount = async (): Promise<number | null> => {
+  const supabase = createClient(
+    process.env['SUPABASE_URL'],
+    process.env['SUPABASE_SERVICE_ROLE']
+  )
+  const { count, error } = await supabase
+    .from(Entities.Subcribers)
+    .select('*', { count: 'exact' })
+
+  if (error) {
+    console.error(error)
+    return null
+  }
+  return count
+}
+
+export default async function SubscribersCount() {
+  const count = await getSubscriberCount()
+  if (!count) return <div className="h-[32px] mb-6"></div>
+
+  return (
+    <div className="inline-block mb-6 px-2 py-1 font-semibold bg-green-100 rounded-md roll-animation">
+      <div className="flex flex-wrap items-center -m-1">
+        <div className="w-auto py-1 px-2">
+          <span className="text-sm">
+            👋 Junte-se a {count.toLocaleString()} inscritos!
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,26 +1,23 @@
-'use client'
-import { QueryClient, QueryClientProvider } from 'react-query'
+import ScrollToTopButton from './components/ui/ScrollToTopButton'
+import { FAQ } from './landing-page/FAQ'
 import { Header } from './landing-page/Header'
 import { Hero } from './landing-page/Hero'
-import { Values } from './landing-page/Values'
-import { FAQ } from './landing-page/FAQ'
 import { HowItWorks } from './landing-page/HowItWorks'
-import ScrollToTopButton from './components/ui/ScrollToTopButton'
+import { Values } from './landing-page/Values'
 
-export default function Page() {
-  const queryClient = new QueryClient()
+export const revalidate = 5
+
+export default async function Page() {
   return (
     <>
-      <QueryClientProvider client={queryClient}>
-        <Header />
-        <main>
-          <Hero />
-          <Values />
-          <HowItWorks />
-          <FAQ />
-          <ScrollToTopButton />
-        </main>
-      </QueryClientProvider>
+      <Header />
+      <main>
+        <Hero />
+        <Values />
+        <HowItWorks />
+        <FAQ />
+        <ScrollToTopButton />
+      </main>
     </>
   )
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -5,7 +5,8 @@ import { Hero } from './landing-page/Hero'
 import { HowItWorks } from './landing-page/HowItWorks'
 import { Values } from './landing-page/Values'
 
-export const revalidate = 5
+const FIFTEEN_MINUTES = 60 * 15
+export const revalidate = FIFTEEN_MINUTES
 
 export default async function Page() {
   return (

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   reactStrictMode: true,
   transpilePackages: ["ui", "eslint-config-custom", "shared"],
+  experimental: {
+    serverActions: true,
+  }
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,7 +49,7 @@
     "@testing-library/react": "^14.0.0",
     "@types/canvas-confetti": "^1.6.0",
     "@types/node": "^17.0.12",
-    "@types/react": "^18.0.22",
+    "@types/react": "^18.2.14",
     "@types/react-dom": "^18.0.7",
     "@vitejs/plugin-react": "^4.0.1",
     "autoprefixer": "^10.4.14",
@@ -69,7 +69,7 @@
     "supabase": "^1.68.6",
     "tailwindcss": "^3.3.2",
     "ts-node": "^10.9.1",
-    "typescript": "^4.5.3",
+    "typescript": "^5.1.6",
     "vitest": "^0.32.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1197,7 +1197,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.0.22":
+"@types/react@*", "@types/react@^18.2.14":
   version "18.2.14"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.14.tgz#fa7a6fecf1ce35ca94e74874f70c56ce88f7a127"
   integrity sha512-A0zjq+QN/O0Kpe30hA1GidzyFjatVvrpIvWLxD+xv67Vt91TWWgco9IvrJBkeyHm1trGaFS/FSGqPlhyeZRm0g==
@@ -6077,14 +6077,14 @@ types@*:
   resolved "https://registry.npmjs.org/types/-/types-0.1.1.tgz"
   integrity sha512-JuntZtJj4MKLE9x/XBs7IjsznYhzETwr34pw3XJTKvgYtAMdeMG+o8x8U85E5Lm6eCPa1DdOdGVsHMwq4ZnZAg==
 
-typescript@^4.5.3:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
 typescript@^5.1.3:
   version "5.1.6"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz"
+  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
+
+typescript@^5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
   integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
 ufo@^1.1.2:


### PR DESCRIPTION
In this branch, I use server components to not make a count of subscribers on each user reload.

## Problem
When the user enters www.trampardecasa.com.br the page makes a request to `/api/subscribers` endpoint and this request response is a result of a database query. This is not necessary and very expensive for the database

## Solution
With [Server component](https://nextjs.org/docs/getting-started/react-essentials#server-components) I can control the "frequency" of rendering with caching. To make this I export a variable called [`revalidate`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate).

The revalidate variable is part of a [Route Segment Config](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config) feature. 

By default, this variable is false but the time is measured in seconds
