### PR TITLE
Fixing wrong logo on mobile menu

### DIFF
--- a/apps/web/app/components/Header.tsx
+++ b/apps/web/app/components/Header.tsx
@@ -1,7 +1,7 @@
 'use client'
+import Image from 'next/image'
 import { useState } from 'react'
 import { LandingPageRoutes } from '../landing-page/landingPageRoutes'
-import Image from 'next/image'
 
 export const Header = () => {
   const [isMobileMenuOpen, setMobileMenuVisibility] = useState(false)
@@ -77,9 +77,11 @@ export const Header = () => {
                 <div className="flex items-center justify-between -m-2">
                   <div className="w-auto p-2">
                     <a className="inline-block" href="/">
-                      <img
-                        src="images/casa.png"
-                        alt="Logo da Trampar de Casa"
+                      <Image
+                        src="/images/logo.svg"
+                        width={70}
+                        height={70}
+                        alt="Logotipo da Trampar De Casa"
                       />
                     </a>
                   </div>


### PR DESCRIPTION
### **Identified issue**
While navigating I realized that currently the mobile menu is displaying the former logo.
![image](https://github.com/ocodista/trampar-de-casa/assets/57651321/806cd1be-aff4-4f91-863b-4f3e58f56355)

### **Fix**
After this fix, it should look like this:
![image](https://github.com/ocodista/trampar-de-casa/assets/57651321/292333e1-e9ac-4b26-ba6f-04f70fd1c2d4)
