### PR TITLE
Improve email-sender worker

### DIFF
--- a/apps/auto-email-sender/email-sender/src/emailSender.ts
+++ b/apps/auto-email-sender/email-sender/src/emailSender.ts
@@ -1,10 +1,7 @@
-import { GetMessage } from 'amqplib'
-import { Resend } from 'resend'
 import { EmailQueues } from 'shared'
 import { createRabbitMqChannel } from 'shared/src/queue/createRabbitMqChannel'
 import { CONFIG } from '../config'
-import { chunkArray } from './chunkArray'
-import { sendEmail } from './sendEmail'
+import { saveOnEmailChunk } from './saveOnEmailChunk'
 
 export type EmailComposerContent = Record<string, string>
 
@@ -13,36 +10,13 @@ export const emailSender = async () => {
     password: CONFIG.RABBITMQ_PASS,
     user: CONFIG.RABBITMQ_USER,
   })
-  const resend = new Resend(CONFIG.RESEND_KEY)
-  const emailComposerItems: EmailComposerContent[] = []
-  await channelToConsume.assertQueue(EmailQueues.EmailSender, {
-    durable: true,
-  })
+  await channelToConsume.assertQueue(EmailQueues.EmailSender, {})
+  await channelToConsume.prefetch(25)
+  await channelToConsume.consume(EmailQueues.EmailSender, async (msg) => {
+    if (!msg) return
 
-  let message = await channelToConsume.get(EmailQueues.EmailSender)
-  while (message) {
-    if (!message) break
-    const messageContent = JSON.parse(
-      message.content.toString()
-    ) as EmailComposerContent
-    emailComposerItems.push(messageContent)
-    if (message) {
-      channelToConsume.ack(message as GetMessage)
-    }
-    message = await channelToConsume.get(EmailQueues.EmailSender)
-  }
-  const chunks = chunkArray(emailComposerItems, 25)
-  for (const [index, chunk] of chunks.entries()) {
-    const promises = chunk.map(
-      async (emailComposerItem: EmailComposerContent) => {
-        const [email, html] = Object.entries(emailComposerItem)[0]
-        return await sendEmail(resend.emails, email, html)
-      }
-    )
-    console.log(`\nWaiting for ${index + 1}/${chunks.length} chunk...`)
-    await Promise.all(promises)
-    console.log('\n\n')
-  }
+    await saveOnEmailChunk(msg, channelToConsume)
+  })
 
   return
 }

--- a/apps/auto-email-sender/email-sender/src/saveOnEmailChunk.ts
+++ b/apps/auto-email-sender/email-sender/src/saveOnEmailChunk.ts
@@ -9,7 +9,7 @@ let currentEmailChunk: ConsumeMessage[] = []
 const resend = new Resend(CONFIG.RESEND_KEY)
 const RESEND_SENDING_LIMIT = 25
 
-export const sendEmailChunks = withExecutionTimeLogging(
+export const sendEmailChunk = withExecutionTimeLogging(
   async (buffers: ConsumeMessage[], channel: Channel) => {
     const promises = buffers.map(async (message) => {
       const content = JSON.parse(
@@ -36,7 +36,7 @@ export const saveOnEmailChunk = async (
   currentEmailChunk.push(emailComposerMessage)
 
   if (currentEmailChunk.length === RESEND_SENDING_LIMIT) {
-    await sendEmailChunks(currentEmailChunk, channel)
+    await sendEmailChunk(currentEmailChunk, channel)
 
     currentEmailChunk = []
   }

--- a/apps/auto-email-sender/email-sender/src/saveOnEmailChunk.ts
+++ b/apps/auto-email-sender/email-sender/src/saveOnEmailChunk.ts
@@ -1,0 +1,43 @@
+import { Channel, ConsumeMessage } from 'amqplib'
+import { Resend } from 'resend'
+import { withExecutionTimeLogging } from 'shared/src/observability/withExecutionTimeLogging'
+import { CONFIG } from '../config'
+import { EmailComposerContent } from './emailSender'
+import { sendEmail } from './sendEmail'
+
+let currentEmailChunk: ConsumeMessage[] = []
+const resend = new Resend(CONFIG.RESEND_KEY)
+const RESEND_SENDING_LIMIT = 25
+
+export const sendEmailChunks = withExecutionTimeLogging(
+  async (buffers: ConsumeMessage[], channel: Channel) => {
+    const promises = buffers.map(async (message) => {
+      const content = JSON.parse(
+        message.content.toString()
+      ) as EmailComposerContent
+
+      const [email, html] = Object.entries(content)[0]
+      try {
+        await sendEmail(resend.emails, email, html)
+        channel.ack(message)
+      } catch {
+        channel.nack(message, false, true)
+      }
+    })
+    await Promise.all(promises)
+  },
+  { name: 'sendEmailChunks' }
+)
+
+export const saveOnEmailChunk = async (
+  emailComposerMessage: ConsumeMessage,
+  channel: Channel
+) => {
+  currentEmailChunk.push(emailComposerMessage)
+
+  if (currentEmailChunk.length === RESEND_SENDING_LIMIT) {
+    await sendEmailChunks(currentEmailChunk, channel)
+
+    currentEmailChunk = []
+  }
+}

--- a/apps/auto-email-sender/email-sender/src/sendEmail.ts
+++ b/apps/auto-email-sender/email-sender/src/sendEmail.ts
@@ -33,5 +33,6 @@ export const sendEmail = async (
     logSuccessfully(email)
   } catch (error) {
     logFailure(email, error)
+    throw error
   }
 }

--- a/apps/auto-email-sender/email-sender/src/sendEmail.ts
+++ b/apps/auto-email-sender/email-sender/src/sendEmail.ts
@@ -1,21 +1,11 @@
-import fs from 'node:fs'
-import path from 'path'
 import { Resend } from 'resend'
 
 const logSuccessfully = (email: string) => {
   console.log(`Successfully sent to ${email}!`)
-  fs.appendFileSync(
-    path.resolve(__dirname, `./openings-email/sent-emails.txt`),
-    `${email}\n`
-  )
 }
 
 const logFailure = (email: string, error: unknown) => {
   console.error(`Error sending to: ${email}`, error)
-  fs.appendFileSync(
-    path.resolve(__dirname, `./openings-email/failed-emails.txt`),
-    `${email}\n`
-  )
 }
 
 export const sendEmail = async (

--- a/packages/shared/src/test/helpers/rabbitMQ.ts
+++ b/packages/shared/src/test/helpers/rabbitMQ.ts
@@ -4,12 +4,14 @@ import { vi } from 'vitest'
 export const assertQueueStub = vi.fn()
 export const consumerStub = vi.fn()
 export const ackStub = vi.fn()
+export const nackStub = vi.fn()
 export const sendToQueueStub = vi.fn()
 export const prefetchStub = vi.fn()
 export const getStub = vi.fn()
 
 export const channelMock = {
   ack: ackStub,
+  nack: nackStub,
   assertQueue: assertQueueStub,
   consume: consumerStub,
   sendToQueue: sendToQueueStub,


### PR DESCRIPTION
In the email-sender service, we consume each message via polling and store them. after this, we acknowledge the message.  

This means that we remove all messages from the queue, save them on memory, and send them. If the service stops, we lose ALL messages.

## Solution
```mermaid
flowchart LR
rabbitMQ-->sendEmail
sendEmail-->saveEmailChunk{Has 25 messages stored?}
saveEmailChunk -->|Yes| sendEmailChunk
subgraph For each email
sendEmailChunk-->resend{email sent?}
resend -->|Yes|channelack['channel.ack']
resend -->|No|channelnack['channel.nack']
end
```
We store messages on `currentEmailChunk` array, and if this array reach 25 items, we send and only after this, do we verify if this message must be acknowledged or re-queue.
