### PR TITLE
moving PartnerCompanies component

### DIFF
--- a/apps/web/app/landing-page/Hero.tsx
+++ b/apps/web/app/landing-page/Hero.tsx
@@ -20,16 +20,16 @@ export const Hero = () => {
                 Levamos as melhores oportunidades de trampo até você.
               </p>
               <SubscriberForm />
-              <PartnerCompanies />
             </div>
             <div className="w-full p-8 lg:w-1/2">
               <Image
-                className="mx-auto transform rounded-xl object-cover transition duration-1000 ease-in-out hover:-translate-y-4 max-lg:aspect-video max-lg:w-10/12 max-md:w-full"
+                className="mx-auto max-h-full transform rounded-xl object-cover transition duration-1000 ease-in-out hover:-translate-y-4 max-lg:aspect-video max-lg:w-10/12 max-md:w-full"
                 src="/images/HO-brasil.webp"
                 alt="Escritório com uma paisagem natural ao fundo que pode ser vista pelas janelas"
                 width={583}
                 height={583}
               />
+              <PartnerCompanies />
             </div>
           </div>
         </div>

--- a/apps/web/app/landing-page/Hero.tsx
+++ b/apps/web/app/landing-page/Hero.tsx
@@ -29,10 +29,10 @@ export const Hero = () => {
                 width={583}
                 height={583}
               />
-              <PartnerCompanies />
             </div>
           </div>
         </div>
+        <PartnerCompanies />
       </div>
     </>
   )

--- a/apps/web/app/landing-page/PartnerCompanies.tsx
+++ b/apps/web/app/landing-page/PartnerCompanies.tsx
@@ -72,7 +72,7 @@ const CompanySection = ({ name, imagePath, url, description }: Company) => (
 
 export const PartnerCompanies = () => {
   return (
-    <section>
+    <section className="max-w-full">
       <p className="text-sm font-semibold text-gray-500">
         EMPRESAS QUE APOIAM O TRABALHO REMOTO
       </p>

--- a/apps/web/app/landing-page/PartnerCompanies.tsx
+++ b/apps/web/app/landing-page/PartnerCompanies.tsx
@@ -72,7 +72,7 @@ const CompanySection = ({ name, imagePath, url, description }: Company) => (
 
 export const PartnerCompanies = () => {
   return (
-    <section className="max-w-full">
+    <section className="max-w-full px-8 pt-6">
       <p className="text-sm font-semibold text-gray-500">
         EMPRESAS QUE APOIAM O TRABALHO REMOTO
       </p>

--- a/apps/web/app/landing-page/PartnerCompanies.tsx
+++ b/apps/web/app/landing-page/PartnerCompanies.tsx
@@ -72,7 +72,7 @@ const CompanySection = ({ name, imagePath, url, description }: Company) => (
 
 export const PartnerCompanies = () => {
   return (
-    <section className="max-w-full px-8 pt-6">
+    <section className="max-w-full space-y-4 px-8 pt-6">
       <p className="text-sm font-semibold text-gray-500">
         EMPRESAS QUE APOIAM O TRABALHO REMOTO
       </p>

--- a/apps/web/app/landing-page/PartnerCompanies.tsx
+++ b/apps/web/app/landing-page/PartnerCompanies.tsx
@@ -97,6 +97,18 @@ export const PartnerCompanies = () => {
               />
             ))}
           </span>
+          <span
+            className="animate-scroll-left group-hover:paused flex gap-10"
+            style={{ transform: 'translateX(100%)' }}
+          >
+            {companies.map((company) => (
+              <CompanySection
+                key={company.name}
+                {...company}
+                aria-hidden={true}
+              />
+            ))}
+          </span>
         </span>
       </div>
     </section>

--- a/apps/web/app/landing-page/SubscriberForm.tsx
+++ b/apps/web/app/landing-page/SubscriberForm.tsx
@@ -23,7 +23,7 @@ const ErrorWrapper = ({
   messages: MultipleFieldErrors
 }) => (
   <section className="my-4 mb-16 min-h-[30px] text-sm text-red-600">
-    {message}
+    <p>{message}</p>
   </section>
 )
 

--- a/apps/web/app/landing-page/SubscriberForm.tsx
+++ b/apps/web/app/landing-page/SubscriberForm.tsx
@@ -5,7 +5,7 @@ import { useLoadingContext } from 'app/contexts/LoadingContext'
 import { ToastComponentProps, useToast } from 'app/hooks/use-toast'
 import { StatusCodes } from 'http-status-codes'
 import { useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { MultipleFieldErrors, useForm } from 'react-hook-form'
 import { ApiRoutes } from 'shared/src/enums/apiRoutes'
 import { z } from 'zod'
 import fireworks from '../utils/confetti'
@@ -15,6 +15,17 @@ const validationSchema = z.object({
   email: z.string().email('Insira um e-mail válido!'),
 })
 type ValidationSchema = z.infer<typeof validationSchema>
+
+const ErrorWrapper = ({
+  message,
+}: {
+  message: string
+  messages: MultipleFieldErrors
+}) => (
+  <section className="my-4 mb-16 min-h-[30px] text-sm text-red-600">
+    {message}
+  </section>
+)
 
 export function SubscriberForm() {
   const { isLoading, withLoading } = useLoadingContext()
@@ -150,13 +161,7 @@ export function SubscriberForm() {
           </div>
         </form>
       </div>
-      <section className="my-4 mb-16 min-h-[30px] text-sm text-red-600">
-        <ErrorMessage
-          name="email"
-          errors={errors}
-          render={({ message }) => <p>{message}</p>}
-        />
-      </section>
+      <ErrorMessage name="email" errors={errors} render={ErrorWrapper} />
     </>
   )
 }


### PR DESCRIPTION
Move the PartnerCompanies component to the bottom of the image on the Hero component
### Desktop 
![localhost_3000_](https://github.com/ocodista/trampar-de-casa/assets/68869379/de412446-5d9e-4b37-9e56-89234e4e7894)
### Mobile
![localhost_3000_(iPhone XR)](https://github.com/ocodista/trampar-de-casa/assets/68869379/5caf0d4e-06db-4926-9582-7d7106a581b8)

### Fix empty element
Error messages of `SubscriberForm` was rendered inside a "static" eleement:
```tsx
     <section className="my-4 mb-16 min-h-[30px] text-sm text-red-600">
        <ErrorMessage
          name="email"
          errors={errors}
          render={({ message }) => <p>{message}</p>}
        />
      </section>
```
This approach causes unnecessary spacing:
![image](https://github.com/ocodista/trampar-de-casa/assets/68869379/dc02d9fd-81ed-4cc5-b077-beccb1283502)

If we create a "wrapper" to `render` prop we remove this space:

```tsx
const ErrorWrapper = ({
  message,
}: {
  message: string
  messages: MultipleFieldErrors
}) => (
  <section className="my-4 mb-16 min-h-[30px] text-sm text-red-600">
    <p>{message}</p>
  </section>
)
```
With this change, we render the element only when there is an error message. This means we no longer have unnecessary space.
![image](https://github.com/ocodista/trampar-de-casa/assets/68869379/f986a314-2d66-42bf-bfae-e7424320e88f)
