### PR TITLE
fix profile email template preview | fix english level session on profile form

### DIFF
--- a/apps/web/app/api/subscribers/db.ts
+++ b/apps/web/app/api/subscribers/db.ts
@@ -67,6 +67,11 @@ export async function updateSubscriber(
   id: string,
   { receiveEmailConfig, ...body }: ProfileSchema
 ) {
+  const sanitizeEnglishLevelInput = (englishLevel: EnglishLevel) => {
+    if (englishLevel === EnglishLevel.None) return null
+    return englishLevel
+  }
+
   const { data, error } = await supabaseClient
     .from(Entities.Subcribers)
     .update({
@@ -77,9 +82,7 @@ export async function updateSubscriber(
       startedWorkingAt:
         body.startedWorkingAt as unknown as Subscriber['startedWorkingAt'],
       skillsId: body.skillsId,
-      englishLevel: EnglishLevel[
-        body.englishLevel
-      ] as Subscriber['englishLevel'],
+      englishLevel: sanitizeEnglishLevelInput(body.englishLevel),
     })
     .eq('id', id)
     .select()

--- a/apps/web/app/api/subscribers/db.ts
+++ b/apps/web/app/api/subscribers/db.ts
@@ -68,8 +68,7 @@ export async function updateSubscriber(
   { receiveEmailConfig, ...body }: ProfileSchema
 ) {
   const sanitizeEnglishLevelInput = (englishLevel: EnglishLevel) => {
-    if (englishLevel === EnglishLevel.None) return null
-    return englishLevel
+    return englishLevel === EnglishLevel.None ? null : englishLevel;
   }
 
   const { data, error } = await supabaseClient

--- a/packages/shared/emails/ProfileEmail.tsx
+++ b/packages/shared/emails/ProfileEmail.tsx
@@ -18,6 +18,7 @@ interface ProfileEmailTemplateProps {
 
 const GIF_URL = 'https://trampardecasa.com.br/images/form.gif'
 const LOGO_URL = 'https://trampardecasa.com.br/images/logo.png'
+const EMAIL_PREVIEW = 'A funcionalidade mais pedida chegou!'
 
 export const ProfileEmailTemplate = ({
   profileUrl,
@@ -25,9 +26,7 @@ export const ProfileEmailTemplate = ({
   <Tailwind>
     <Html>
       <Head />
-      <Preview>
-        The sales intelligence platform that helps you uncover qualified leads.
-      </Preview>
+      <Preview>{EMAIL_PREVIEW}</Preview>
       <Body style={main}>
         <Container style={container} className="w-full max-w-full">
           <Img


### PR DESCRIPTION
In this pr I fixed the text preview of the profile email template and found a bug on the profile form.

### Bug
When we save a profile with "Não informar" checkbox selected, the frontend sends a "None" value for the backend. The "None" makes sense on the frontend but this value does not exist on the database. When the user sets "None" to the English level in the database this should be equal to a `NULL`
