### PR TITLE
create dynamic subject on `email-composer` service

### DIFF
--- a/apps/auto-email-sender/email-composer/src/parsePreRenderMessage.ts
+++ b/apps/auto-email-sender/email-composer/src/parsePreRenderMessage.ts
@@ -2,10 +2,12 @@ import { GetMessage } from 'amqplib'
 import { createEmailHtml } from './createEmailHtml'
 import { EmailPreRenderMessage } from './emailComposer'
 import { getHtmlRoles } from './getHtmlRoles'
+export const rolesSubject = (roles: number) =>
+  `${roles} Vagas para você Trampar de Casa`
 
 export const parsePreRenderMessage = async (
   msgContent: GetMessage['content']
-): Promise<Record<string, string>> => {
+): Promise<Record<string, { html: string; subject: string }>> => {
   const emailPreRender = JSON.parse(
     msgContent.toString()
   ) as EmailPreRenderMessage
@@ -14,5 +16,7 @@ export const parsePreRenderMessage = async (
   const rolesHTML = await getHtmlRoles(roles)
   const bodyHTML = `${headerHTML}${rolesHTML}${footerHTML}`
   const renderedEmail = await createEmailHtml(bodyHTML)
-  return { [email]: renderedEmail }
+  return {
+    [email]: { html: renderedEmail, subject: rolesSubject(roles.length) },
+  }
 }

--- a/apps/auto-email-sender/email-composer/src/test/emailComposer.spec.ts
+++ b/apps/auto-email-sender/email-composer/src/test/emailComposer.spec.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker'
-import { ConsumeMessage } from 'amqplib'
+import { GetMessage } from 'amqplib'
 import { EmailQueues } from 'shared'
 import * as createRabbitMqConnectionFile from 'shared/src/queue/createRabbitMqConnection'
 import { channelMock, sendToQueueStub } from 'shared/src/test/helpers/rabbitMQ'
@@ -8,7 +8,7 @@ import {
   composeEmail,
   consumePreRenderQueue,
 } from 'src/emailComposer'
-import { parsePreRenderMessage } from 'src/parsePreRenderMessage'
+import { parsePreRenderMessage, rolesSubject } from 'src/parsePreRenderMessage'
 import { vi } from 'vitest'
 import * as createEmailHtmlFile from '../createEmailHtml'
 import * as getHtmlRolesFile from '../getHtmlRoles'
@@ -71,7 +71,7 @@ describe.only('Email Composer Service Tests', () => {
       await consumePreRenderQueue(
         {
           content: Buffer.from(JSON.stringify(prerenderMessageMock)),
-        } as unknown as ConsumeMessage,
+        } as unknown as GetMessage,
         channelMock
       )
 
@@ -80,7 +80,10 @@ describe.only('Email Composer Service Tests', () => {
         EmailQueues.EmailSender,
         Buffer.from(
           JSON.stringify({
-            [emailMock]: createEmailHtmlReturn,
+            [emailMock]: {
+              html: createEmailHtmlReturn,
+              subject: rolesSubject(rolesMock.length),
+            },
           })
         )
       )

--- a/apps/auto-email-sender/email-composer/src/test/filterRoles.spec.ts
+++ b/apps/auto-email-sender/email-composer/src/test/filterRoles.spec.ts
@@ -33,7 +33,7 @@ describe('Get HTML roles', () => {
 
     expect(collectionStub).toBeCalled()
   })
-  it.only('concatenate roles taken on redis', async () => {
+  it('concatenate roles taken on redis', async () => {
     const { findOneStub } = mockMongoDb()
     const rolesIdArray = [faker.string.uuid(), faker.string.uuid()]
     const firstRoleHTML = faker.string.sample()

--- a/apps/auto-email-sender/email-sender/src/baseEmail.ts
+++ b/apps/auto-email-sender/email-sender/src/baseEmail.ts
@@ -1,3 +1,1 @@
 export const EMAIL_FROM = 'Trampar de Casa <comece@trampardecasa.com.br>'
-export const rolesSubject = (roles: number) =>
-  `${roles} Vagas para você Trampar de Casa`

--- a/apps/auto-email-sender/email-sender/src/emailSender.ts
+++ b/apps/auto-email-sender/email-sender/src/emailSender.ts
@@ -5,7 +5,10 @@ import { createRabbitMqChannel } from 'shared/src/queue/createRabbitMqChannel'
 import { CONFIG } from '../config'
 import { sendEmails } from './sendEmails'
 
-export type EmailComposerContent = Record<string, string>
+export type EmailComposerContent = Record<
+  string,
+  { html: string; subject: string }
+>
 
 export const emailSender = async () => {
   console.time('emailSender')

--- a/apps/auto-email-sender/email-sender/src/sendEmails.ts
+++ b/apps/auto-email-sender/email-sender/src/sendEmails.ts
@@ -1,6 +1,6 @@
 import { Channel, GetMessage } from 'amqplib'
 import { Resend } from 'resend'
-import { EMAIL_FROM, rolesSubject } from './baseEmail'
+import { EMAIL_FROM } from './baseEmail'
 import { EmailComposerContent } from './emailSender'
 
 export const sendEmails = async (
@@ -15,13 +15,13 @@ export const sendEmails = async (
       message.content.toString()
     ) as EmailComposerContent
 
-    const [email, html] = Object.entries(content)[0]
+    const [email, { html, subject }] = Object.entries(content)[0]
     try {
       await resendCli.emails.send({
         from: EMAIL_FROM,
         to: email,
         html: html,
-        subject: rolesSubject(30),
+        subject,
       })
       channel.ack(message)
     } catch (e) {

--- a/apps/auto-email-sender/email-sender/src/test/factories/messageFactory.ts
+++ b/apps/auto-email-sender/email-sender/src/test/factories/messageFactory.ts
@@ -3,14 +3,15 @@ import { GetMessage } from 'amqplib'
 
 export const messageFactory = () => {
   const emailMock = faker.internet.email()
+  const subjectMock = faker.string.sample()
   const htmlMock = faker.string.sample()
   const messageMock = {
     content: Buffer.from(
       JSON.stringify({
-        [emailMock]: htmlMock,
+        [emailMock]: { html: htmlMock, subject: subjectMock },
       })
     ),
   } as GetMessage
 
-  return { emailMock, htmlMock, messageMock }
+  return { emailMock, htmlMock, messageMock, subjectMock }
 }

--- a/apps/auto-email-sender/email-sender/src/test/sendEmails.spec.ts
+++ b/apps/auto-email-sender/email-sender/src/test/sendEmails.spec.ts
@@ -3,14 +3,14 @@ import {
   channelMock,
   nackStub,
 } from 'shared/src/test/helpers/rabbitMQ'
-import { EMAIL_FROM, rolesSubject } from 'src/baseEmail'
+import { EMAIL_FROM } from 'src/baseEmail'
 import { sendEmails } from 'src/sendEmails'
 import { messageFactory } from './factories/messageFactory'
 import { resendMockFactory } from './factories/resendFactory'
 
 describe('Send Emails', () => {
   it('uses resend to send email chunk', () => {
-    const { messageMock, emailMock, htmlMock } = messageFactory()
+    const { messageMock, emailMock, htmlMock, subjectMock } = messageFactory()
     const { resendMock, sendSpy } = resendMockFactory()
 
     sendEmails([messageMock], channelMock, resendMock)
@@ -19,7 +19,7 @@ describe('Send Emails', () => {
       from: EMAIL_FROM,
       to: emailMock,
       html: htmlMock,
-      subject: rolesSubject(38),
+      subject: subjectMock,
     })
   })
 

--- a/packages/shared/src/test/helpers/mocks.ts
+++ b/packages/shared/src/test/helpers/mocks.ts
@@ -12,10 +12,11 @@ export const supabaseClientMock: SupabaseClient = {
         order: () => ({ data: [] }),
       }),
       eq: () => ({
-        range: () => ({
-          order: () => ({ data: [] }),
+        eq: () => ({
+          range: () => ({
+            order: () => ({ data: [] }),
+          }),
         }),
-        eq: () => [],
       }),
     }),
   }),


### PR DESCRIPTION
In this PR I change the approach to create a subject. Now, we create inside `email-composer` to count roles quantity and show this info on the email subject