### PR TITLE
docs: fix Manifesto path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ O Trampar de Casa é uma iniciativa open-source dedicada a conectar desenvolvedo
 
 Semanalmente, enviamos 1 email com vagas 100% remotas que correspondem ao perfil de nossos inscritos.
 
-## [Manifesto sobre o Trabalho Remoto](./manifesto.MD)
+## [Manifesto sobre o Trabalho Remoto](./manifesto.md)
 
 ## Roadmap do Projeto 🚧
 


### PR DESCRIPTION
The Manifesto's link was redirecting to a non-existent page due to sensitive case

![image](https://github.com/ocodista/trampar-de-casa/assets/61201131/692f4e7d-fb47-4a46-8469-18ee358107c2)
