### PR TITLE
fix: error on validate linkedin url

### DIFF
--- a/apps/web/app/subscribers/profile/profileSchema.ts
+++ b/apps/web/app/subscribers/profile/profileSchema.ts
@@ -25,6 +25,7 @@ export const profileFormSchema = z.object({
     .min(28, {
       message: 'Seu LinkedIn é obrigatório',
     })
+    .trim()
     .startsWith(
       'https://linkedin.com/in/',
       'URL do perfil deve começar com https://linkedin.com/in/'


### PR DESCRIPTION
[PR Reference](https://github.com/ocodista/trampar-de-casa/issues/185)

- Fixing error on validate linkedin url with white space on start of content.