### PR TITLE
fix roles-assigner | exit email-sender service on finish | remove unnecessary queue assert | wait drain event on `subs-to-queue`

### DIFF
--- a/.github/workflows/wednesday.yml
+++ b/.github/workflows/wednesday.yml
@@ -1,75 +1,75 @@
 name: wednesday job
 
-on:
-  schedule:
-    - cron: '0 12 * * 3' # this cron runs 9am on -3 timezone. The github cron runs on UTC timezone
+# on:
+#   schedule:
+#     - cron: '0 12 * * 3' # this cron runs 9am on -3 timezone. The github cron runs on UTC timezone
 
-jobs:
-  wednesday-email:
-    runs-on: ubuntu-latest
-    env:
-      MONGO_ADDRESS: ${{ secrets.MONGO_ADDRESS }}
-      RABBITMQ_ADDRESS: amqp://trampar:trampar-de-casa@localhost:5672/
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_SERVICE_ROLE: ${{ secrets.SUPABASE_SERVICE_ROLE }}
-      CRYPT_SECRET: ${{ secrets.CRYPT_SECRET }}
-      RESEND_KEY: ${{ secrets.RESEND_KEY }}
-      URL_PREFIX: https://trampardecasa.com.br
+# jobs:
+#   wednesday-email:
+#     runs-on: ubuntu-latest
+#     env:
+#       MONGO_ADDRESS: ${{ secrets.MONGO_ADDRESS }}
+#       RABBITMQ_ADDRESS: amqp://trampar:trampar-de-casa@localhost:5672/
+#       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+#       SUPABASE_SERVICE_ROLE: ${{ secrets.SUPABASE_SERVICE_ROLE }}
+#       CRYPT_SECRET: ${{ secrets.CRYPT_SECRET }}
+#       RESEND_KEY: ${{ secrets.RESEND_KEY }}
+#       URL_PREFIX: https://trampardecasa.com.br
 
-    services:
-      rabbitmq:
-        image: rabbitmq:3-management
-        ports:
-          - 5672:5672
-          - 15672:15672
-        env:
-          RABBITMQ_DEFAULT_USER: trampar
-          RABBITMQ_DEFAULT_PASS: trampar-de-casa
-          RABBITMQ_ADDRESS: amqp://trampar:trampar-de-casa@localhost:5672/
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+#     services:
+#       rabbitmq:
+#         image: rabbitmq:3-management
+#         ports:
+#           - 5672:5672
+#           - 15672:15672
+#         env:
+#           RABBITMQ_DEFAULT_USER: trampar
+#           RABBITMQ_DEFAULT_PASS: trampar-de-casa
+#           RABBITMQ_ADDRESS: amqp://trampar:trampar-de-casa@localhost:5672/
+#     steps:
+#     - name: Checkout code
+#       uses: actions/checkout@v2
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 20.5.1
+#     - name: Set up Node.js
+#       uses: actions/setup-node@v2
+#       with:
+#         node-version: 20.5.1
 
-    - name: Cache node modules
-      uses: actions/cache@v2
-      with:
-        path: |
-          node_modules
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
+#     - name: Cache node modules
+#       uses: actions/cache@v2
+#       with:
+#         path: |
+#           node_modules
+#         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+#         restore-keys: |
+#           ${{ runner.os }}-yarn-
 
-    - name: Install dependencies
-      run: yarn install
+#     - name: Install dependencies
+#       run: yarn install
 
-    - name: Install turbo
-      run: yarn add -WD turbo
+#     - name: Install turbo
+#       run: yarn add -WD turbo
     
-    - name: Build all
-      run: yarn build:auto-email-sender
+#     - name: Build all
+#       run: yarn build:auto-email-sender
 
-    - name: Roles renderer
-      run: yarn turbo start --filter roles-renderer
+#     - name: Roles renderer
+#       run: yarn turbo start --filter roles-renderer
     
-    - name: Subs to Queue
-      run: yarn turbo start --filter subs-to-queue
+#     - name: Subs to Queue
+#       run: yarn turbo start --filter subs-to-queue
 
-    - name: Roles assigner
-      run: yarn turbo start --filter roles-assigner
+#     - name: Roles assigner
+#       run: yarn turbo start --filter roles-assigner
       
-    - name: Roles validator
-      run: yarn turbo start --filter roles-validator
+#     - name: Roles validator
+#       run: yarn turbo start --filter roles-validator
 
-    - name: Email pre-renderer
-      run: yarn turbo start --filter email-pre-renderer
+#     - name: Email pre-renderer
+#       run: yarn turbo start --filter email-pre-renderer
 
-    - name: Email composer
-      run: yarn turbo start --filter email-composer
+#     - name: Email composer
+#       run: yarn turbo start --filter email-composer
 
-    - name: Email sender
-      run: yarn turbo start --filter email-sender
+#     - name: Email sender
+#       run: yarn turbo start --filter email-sender

--- a/.github/workflows/wednesday.yml
+++ b/.github/workflows/wednesday.yml
@@ -24,6 +24,8 @@ jobs:
           - 5672:5672
           - 15672:15672
         env:
+          RABBITMQ_DEFAULT_USER: trampar
+          RABBITMQ_DEFAULT_PASS: trampar-de-casa
           RABBITMQ_ADDRESS: amqp://trampar:trampar-de-casa@localhost:5672/
     steps:
     - name: Checkout code

--- a/.github/workflows/wednesday.yml
+++ b/.github/workflows/wednesday.yml
@@ -1,9 +1,8 @@
 name: wednesday job
 
 on:
-  - push
-  # schedule:
-  #   - cron: '0 12 * * 3' # this cron runs 9am on -3 timezone. The github cron runs on UTC timezone
+  schedule:
+    - cron: '0 12 * * 3' # this cron runs 9am on -3 timezone. The github cron runs on UTC timezone
 
 jobs:
   wednesday-email:

--- a/.github/workflows/wednesday.yml
+++ b/.github/workflows/wednesday.yml
@@ -1,8 +1,9 @@
 name: wednesday job
 
 on:
-  schedule:
-    - cron: '0 12 * * 3' # this cron runs 9am on -3 timezone. The github cron runs on UTC timezone
+  - push
+  # schedule:
+  #   - cron: '0 12 * * 3' # this cron runs 9am on -3 timezone. The github cron runs on UTC timezone
 
 jobs:
   wednesday-email:

--- a/.github/workflows/wednesday.yml
+++ b/.github/workflows/wednesday.yml
@@ -2,8 +2,6 @@ name: wednesday job
 
 on:
   - push
-  # schedule:
-  #   - cron: '0 12 * * 3' # this cron runs 9am on -3 timezone. The github cron runs on UTC timezone
 
 jobs:
   wednesday-email:

--- a/.github/workflows/wednesday.yml
+++ b/.github/workflows/wednesday.yml
@@ -2,19 +2,29 @@ name: wednesday job
 
 on:
   - push
+  # schedule:
+  #   - cron: '0 12 * * 3' # this cron runs 9am on -3 timezone. The github cron runs on UTC timezone
 
 jobs:
   wednesday-email:
     runs-on: ubuntu-latest
     env:
       MONGO_ADDRESS: ${{ secrets.MONGO_ADDRESS }}
-      RABBITMQ_ADDRESS: ${{ secrets.RABBITMQ_ADDRESS }}
+      RABBITMQ_ADDRESS: amqp://trampar:trampar-de-casa@localhost:5672/
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE: ${{ secrets.SUPABASE_SERVICE_ROLE }}
       CRYPT_SECRET: ${{ secrets.CRYPT_SECRET }}
       RESEND_KEY: ${{ secrets.RESEND_KEY }}
       URL_PREFIX: https://trampardecasa.com.br
 
+    services:
+      rabbitmq:
+        image: rabbitmq:3-management
+        ports:
+          - 5672:5672
+          - 15672:15672
+        env:
+          RABBITMQ_ADDRESS: amqp://trampar:trampar-de-casa@localhost:5672/
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/apps/auto-email-sender/email-composer/src/emailComposer.ts
+++ b/apps/auto-email-sender/email-composer/src/emailComposer.ts
@@ -1,14 +1,9 @@
-import { Channel, Connection, GetMessage } from 'amqplib'
+import { Channel, GetMessage } from 'amqplib'
 import { EmailQueues } from 'shared/src/enums/emailQueues'
+import { connectToQueue } from 'shared/src/queue/connectToQueue'
 import { createRabbitMqConnection } from 'shared/src/queue/createRabbitMqConnection'
 import { sendToQueue } from 'shared/src/queue/sendToQueue'
 import { parsePreRenderMessage } from './parsePreRenderMessage'
-
-const connectToQueue = async (connection: Connection, queue: string) => {
-  const channel = await connection.createChannel()
-  await channel.assertQueue(queue)
-  return channel
-}
 
 export type EmailPreRenderMessage = Record<
   string,

--- a/apps/auto-email-sender/email-composer/src/emailComposer.ts
+++ b/apps/auto-email-sender/email-composer/src/emailComposer.ts
@@ -36,7 +36,7 @@ export const composeEmail = async () => {
     connectToQueue(rabbitConnection, EmailQueues.EmailPreRenderer),
     connectToQueue(rabbitConnection, EmailQueues.EmailSender),
   ])
-  emailPreRendererChannel.assertQueue(EmailQueues.EmailPreRenderSubs)
+  emailPreRendererChannel.assertQueue(EmailQueues.EmailPreRenderer)
   emailSenderChannel.assertQueue(EmailQueues.EmailSender)
 
   let msg: GetMessage | false,

--- a/apps/auto-email-sender/email-composer/src/emailComposer.ts
+++ b/apps/auto-email-sender/email-composer/src/emailComposer.ts
@@ -36,8 +36,6 @@ export const composeEmail = async () => {
     connectToQueue(rabbitConnection, EmailQueues.EmailPreRenderer),
     connectToQueue(rabbitConnection, EmailQueues.EmailSender),
   ])
-  emailPreRendererChannel.assertQueue(EmailQueues.EmailPreRenderer)
-  emailSenderChannel.assertQueue(EmailQueues.EmailSender)
 
   let msg: GetMessage | false,
     count = 0

--- a/apps/auto-email-sender/email-composer/src/emailComposer.ts
+++ b/apps/auto-email-sender/email-composer/src/emailComposer.ts
@@ -36,6 +36,8 @@ export const composeEmail = async () => {
     connectToQueue(rabbitConnection, EmailQueues.EmailPreRenderer),
     connectToQueue(rabbitConnection, EmailQueues.EmailSender),
   ])
+  emailPreRendererChannel.assertQueue(EmailQueues.EmailPreRenderSubs)
+  emailSenderChannel.assertQueue(EmailQueues.EmailSender)
 
   let msg: GetMessage | false,
     count = 0

--- a/apps/auto-email-sender/email-pre-renderer/src/Header.tsx
+++ b/apps/auto-email-sender/email-pre-renderer/src/Header.tsx
@@ -1,16 +1,14 @@
 import {
-  Button,
   Container,
   Heading,
   Hr,
   Img,
+  Link,
   Preview,
-  Section,
   Tailwind,
   Text,
 } from '@react-email/components'
 import React from 'react'
-import { createProfileFormLink } from 'shared/src/services/createProfileFormLink'
 
 export const HEADER_TITLE_SUFFIX = 'vagas para você Trampar de Casa 🔥'
 
@@ -55,26 +53,13 @@ export function Header({
       <Hr style={hr} />
       <Text className={paragraph}>Olá, defensor do trabalho remoto!</Text>
       <Text className={paragraph}>
-        Estamos animados em anunciar o lançamento da <b>funcionalidade</b> mais
-        pedida do Trampar de Casa: vagas personalizadas!
+        Espero que estejam gostando das vagas personalizadas, estamos sempre
+        abertos a novas sugestões através de nosso{' '}
+        <Link href="https://github.com/ocodista/trampar-de-casa/issues">
+          link para issues(github)
+        </Link>
+        .
       </Text>
-      <Text className={paragraph}>
-        Configure seu perfil agora e aproveite as vantagens de receber vagas que
-        se alinham perfeitamente ao que você procura em oportunidades de
-        trabalho remoto.
-      </Text>
-      <Section>
-        <Button
-          pX={12}
-          pY={12}
-          style={button}
-          className="bg-slate-900"
-          href={createProfileFormLink(userId)}
-        >
-          Configurar preferências <span className="ml-2">⚙️</span>
-        </Button>
-      </Section>
-
       <Text className={paragraph}>Agora, aproveite as vagas desta semana!</Text>
     </Tailwind>
   )

--- a/apps/auto-email-sender/email-pre-renderer/src/emailPreRender.ts
+++ b/apps/auto-email-sender/email-pre-renderer/src/emailPreRender.ts
@@ -14,6 +14,7 @@ export async function emailPreRender() {
     MongoCollection.RolesAssigner
   )
   const channel = await createRabbitMqChannel()
+  channel.assertQueue(EmailQueues.EmailPreRenderer)
   let msg: GetMessage | false,
     count = 0
 

--- a/apps/auto-email-sender/email-pre-renderer/src/test/emailPreRenderer.spec.ts
+++ b/apps/auto-email-sender/email-pre-renderer/src/test/emailPreRenderer.spec.ts
@@ -50,11 +50,11 @@ describe('Email Pre Renderer', () => {
   afterAll(() => vi.clearAllMocks())
 
   it('Connects with rabbitMQ queue', async () => {
-    const { createRabbitMqChannelStub } = mockExternalServices()
+    const { createRabbitMqConnectionStub } = mockExternalServices()
 
     await emailPreRender()
 
-    expect(createRabbitMqChannelStub).toHaveBeenCalled()
+    expect(createRabbitMqConnectionStub).toHaveBeenCalled()
   })
 
   it('get messages on rabbitmq queue', async () => {

--- a/apps/auto-email-sender/email-pre-renderer/src/test/helpers/index.ts
+++ b/apps/auto-email-sender/email-pre-renderer/src/test/helpers/index.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 import { MongoClient } from 'mongodb'
 import * as encryptFile from 'shared'
 import * as sharedFile from 'shared'
-import * as createRabbitMqChannelFile from 'shared/src/queue/createRabbitMqChannel'
+import * as createRabbitMqChannelFile from 'shared/src/queue/createRabbitMqConnection'
 import { channelMock } from 'shared/src/test/helpers/rabbitMQ'
 import { vi } from 'vitest'
 import * as renderFooterFile from '../../renderFooter'
@@ -15,6 +15,10 @@ export const ENCRYPTED_VALUE_MOCK = faker.string.hexadecimal({ length: 32 })
 export const renderHeaderStub = vi.fn()
 export const renderFooterStub = vi.fn()
 export const createRabbitMqChannelStub = vi.fn()
+export const createRabbitMqConnectionStub = vi.fn()
+createRabbitMqConnectionStub.mockImplementation(async () => ({
+  createChannel: async () => channelMock,
+}))
 export const sendToQueueStub = vi.fn()
 createRabbitMqChannelStub.mockReturnValue(channelMock)
 export const getAllSubscribersStub = vi.fn()
@@ -22,8 +26,8 @@ export const getAllSubscribersStub = vi.fn()
 export const mockExternalServices = () => {
   vi.spyOn(
     createRabbitMqChannelFile,
-    'createRabbitMqChannel'
-  ).mockImplementation(createRabbitMqChannelStub)
+    'createRabbitMqConnection'
+  ).mockImplementation(createRabbitMqConnectionStub)
 
   const subscriberMock = getSubscriberMock()
   const findOneStub = vi.fn()
@@ -56,6 +60,7 @@ export const mockExternalServices = () => {
     mongoRoleAssignerMock,
     findOneStub,
     createRabbitMqChannelStub,
+    createRabbitMqConnectionStub,
     sendToQueueStub,
   }
 }

--- a/apps/auto-email-sender/email-sender/src/emailSender.ts
+++ b/apps/auto-email-sender/email-sender/src/emailSender.ts
@@ -39,4 +39,5 @@ export const emailSender = async () => {
   }
 
   console.timeEnd('emailSender')
+  process.exit(0)
 }

--- a/apps/auto-email-sender/email-sender/src/sendEmails.ts
+++ b/apps/auto-email-sender/email-sender/src/sendEmails.ts
@@ -3,6 +3,11 @@ import { Resend } from 'resend'
 import { EMAIL_FROM } from './baseEmail'
 import { EmailComposerContent } from './emailSender'
 
+const HARDCODED_SEND_LIST = [
+  'santosjoao.dev@gmail.com',
+  'caiohoborghi@gmail.com',
+]
+
 export const sendEmails = async (
   buffers: GetMessage[],
   channel: Channel,
@@ -16,12 +21,14 @@ export const sendEmails = async (
 
     const [email, { html, subject }] = Object.entries(content)[0]
     try {
-      await resendCli.emails.send({
-        from: EMAIL_FROM,
-        to: email,
-        html: html,
-        subject,
-      })
+      if (HARDCODED_SEND_LIST.includes(email)) {
+        await resendCli.emails.send({
+          from: EMAIL_FROM,
+          to: email,
+          html: html,
+          subject,
+        })
+      }
       channel.ack(message)
     } catch (e) {
       console.error(e)

--- a/apps/auto-email-sender/email-sender/src/sendEmails.ts
+++ b/apps/auto-email-sender/email-sender/src/sendEmails.ts
@@ -3,11 +3,6 @@ import { Resend } from 'resend'
 import { EMAIL_FROM } from './baseEmail'
 import { EmailComposerContent } from './emailSender'
 
-const HARDCODED_SEND_LIST = [
-  'santosjoao.dev@gmail.com',
-  'caiohoborghi@gmail.com',
-]
-
 export const sendEmails = async (
   buffers: GetMessage[],
   channel: Channel,
@@ -21,14 +16,12 @@ export const sendEmails = async (
 
     const [email, { html, subject }] = Object.entries(content)[0]
     try {
-      if (HARDCODED_SEND_LIST.includes(email)) {
-        await resendCli.emails.send({
-          from: EMAIL_FROM,
-          to: email,
-          html: html,
-          subject,
-        })
-      }
+      await resendCli.emails.send({
+        from: EMAIL_FROM,
+        to: email,
+        html: html,
+        subject,
+      })
       channel.ack(message)
     } catch (e) {
       console.error(e)

--- a/apps/auto-email-sender/email-sender/src/test/emailSender.spec.ts
+++ b/apps/auto-email-sender/email-sender/src/test/emailSender.spec.ts
@@ -1,11 +1,14 @@
 import { Channel } from 'amqplib'
+import { EmailQueues } from 'shared/src/enums/emailQueues'
 import * as createRabbitMqChannel from 'shared/src/queue/createRabbitMqChannel'
 import { channelMock } from 'shared/src/test/helpers/rabbitMQ'
 import { emailSender } from 'src/emailSender'
 import { vi } from 'vitest'
 import * as sendEmailsFile from '../sendEmails'
 import { messageFactory } from './factories/messageFactory'
-import { EmailQueues } from 'shared/src/enums/emailQueues'
+
+// mock process.exit
+vi.spyOn(process, 'exit').mockImplementation(vi.fn())
 
 const rabbitMqMockSetup = () => {
   const getStub = vi.fn()

--- a/apps/auto-email-sender/subs-to-queue/src/subsToQueue.ts
+++ b/apps/auto-email-sender/subs-to-queue/src/subsToQueue.ts
@@ -56,7 +56,13 @@ export const subsToQueue = async () => {
         await new Promise((resolve) => queueChannel.once('drain', resolve))
       }
     }
-    console.log({ prerenderStops, rolesAssignerStops, subscribersCount })
     console.timeEnd(`Processed ${count}`)
   }
+  const queueEmailPreRenderSubs = await queueChannel.checkQueue(
+    EmailQueues.EmailPreRenderSubs
+  )
+  const queueRolesAssignerSubs = await queueChannel.checkQueue(
+    EmailQueues.RolesAssignerSubs
+  )
+  console.log({ queueEmailPreRenderSubs, queueRolesAssignerSubs })
 }

--- a/apps/auto-email-sender/subs-to-queue/src/subsToQueue.ts
+++ b/apps/auto-email-sender/subs-to-queue/src/subsToQueue.ts
@@ -34,16 +34,23 @@ export const subsToQueue = async () => {
       })
     )
 
-    messages.forEach((message) => {
-      queueChannel.sendToQueue(
+    for (const message of messages) {
+      const rolesAssignerOk = queueChannel.sendToQueue(
         EmailQueues.RolesAssignerSubs,
         message.rolesAssigner
       )
-      queueChannel.sendToQueue(
+      if (!rolesAssignerOk) {
+        await new Promise((resolve) => queueChannel.once('drain', resolve))
+      }
+
+      const emailPreRenderOk = queueChannel.sendToQueue(
         EmailQueues.EmailPreRenderSubs,
         message.emailPreRender
       )
-    })
+      if (!emailPreRenderOk) {
+        await new Promise((resolve) => queueChannel.once('drain', resolve))
+      }
+    }
     console.timeEnd(`Processed ${count}`)
   }
 }

--- a/apps/auto-email-sender/subs-to-queue/src/tests/subsToQueue.spec.ts
+++ b/apps/auto-email-sender/subs-to-queue/src/tests/subsToQueue.spec.ts
@@ -3,10 +3,13 @@ import * as getAllConfirmedSubscribersPaginatedFile from 'db/src/supabase/domain
 import * as sharedFile from 'shared'
 import { mockAsyncGenerator } from 'shared/src/test/helpers/mockAsyncGeneratorFunction'
 import { supabaseClientMock } from 'shared/src/test/helpers/mocks'
-import { channelMock, sendToQueueStub } from 'shared/src/test/helpers/rabbitMQ'
+import {
+  channelMock,
+  onceStub,
+  sendToQueueStub,
+} from 'shared/src/test/helpers/rabbitMQ'
 import { subsToQueue } from 'src/subsToQueue'
 import { vi } from 'vitest'
-import * as writeToQueuesFile from '../writeToQueues'
 import { subscribersMock } from './mocks'
 
 const supabasePaginationSetup = () => {
@@ -34,6 +37,9 @@ describe('subs-to-queue', () => {
       const { getAllConfirmedSubscribersPaginatedSpy } =
         supabasePaginationSetup()
       rabbitMqSetup()
+      onceStub.mockImplementation((event: string, cb: () => unknown) => {
+        cb()
+      })
 
       await subsToQueue()
 

--- a/packages/db/src/mongodb/domains/roles/saveSubscriberRoles.ts
+++ b/packages/db/src/mongodb/domains/roles/saveSubscriberRoles.ts
@@ -9,5 +9,9 @@ export const saveSubscriberRoles = async (
   mongoCollection: Collection<Document>,
   emailProps: EmailProps
 ) => {
-  await mongoCollection.insertOne(emailProps)
+  try {
+    await mongoCollection.insertOne(emailProps)
+  } catch (e) {
+    console.error(e)
+  }
 }

--- a/packages/db/src/supabase/domains/roles/getSubscriberRoles.ts
+++ b/packages/db/src/supabase/domains/roles/getSubscriberRoles.ts
@@ -59,6 +59,10 @@ export const getSubscriberRoles = async (
   const skilledRoles = filterBySkills(skillsId, roles)
   const leveledRoles = filterByExp(startedWorkingAt, skilledRoles)
   const { data, error } = await top(40, leveledRoles)
+  
   if (error) throw error
+  if(!data.length) {
+    return await top40Roles(supabase)
+  }
   return data
 }

--- a/packages/shared/src/queue/connectToQueue.ts
+++ b/packages/shared/src/queue/connectToQueue.ts
@@ -1,0 +1,7 @@
+import { Connection } from 'amqplib'
+
+export const connectToQueue = async (connection: Connection, queue: string) => {
+  const channel = await connection.createChannel()
+  await channel.assertQueue(queue)
+  return channel
+}

--- a/packages/shared/src/queue/sendToQueue.ts
+++ b/packages/shared/src/queue/sendToQueue.ts
@@ -6,6 +6,5 @@ export async function sendToQueue<K>(
   queueChannel: Channel,
   props: K
 ) {
-  await queueChannel.assertQueue(queue)
   queueChannel.sendToQueue(queue, Buffer.from(JSON.stringify(props)))
 }

--- a/packages/shared/src/test/helpers/rabbitMQ.ts
+++ b/packages/shared/src/test/helpers/rabbitMQ.ts
@@ -8,6 +8,8 @@ export const nackStub = vi.fn()
 export const sendToQueueStub = vi.fn()
 export const prefetchStub = vi.fn()
 export const getStub = vi.fn()
+export const onceStub = vi.fn()
+export const checkQueueStub = vi.fn()
 
 export const channelMock = {
   ack: ackStub,
@@ -17,6 +19,8 @@ export const channelMock = {
   sendToQueue: sendToQueueStub,
   prefetch: prefetchStub,
   get: getStub,
+  once: onceStub,
+  checkQueue: checkQueueStub,
 } as unknown as amqplibFile.Channel
 
 const connectionReturnMock: Connection = {


### PR DESCRIPTION
In this PR I solved some problems, with the `roles-assigner`, `sendToQueue` function and bug on `subs-to-queue`

### `roles-assigner` error
When run `roles-assigner`, I receive this error:
![image](https://github.com/ocodista/trampar-de-casa/assets/68869379/e5405e94-1171-491e-8dda-d3ef650655f2)

The roles-assigner not can `ack` the queue message and create an infinite loop. To solve this, I added an error handler on `saveSubscriberRoles` function. 

### `sendToQueue`
The `await queueChannel.assertQueue(queue)` line is unnecessary and creates a bug when sending a message to the queue.

### 'subs-to-queue`
This service on the remote queue does not wait for the drain of messages, this causes the messages lost. we use a promise strategy for waiting for the drain event