### PR TITLE
Allow Linkedin URL field accept www

### DIFF
--- a/apps/web/app/subscribers/profile/profileSchema.ts
+++ b/apps/web/app/subscribers/profile/profileSchema.ts
@@ -26,9 +26,14 @@ export const profileFormSchema = z.object({
       message: 'Seu LinkedIn é obrigatório',
     })
     .trim()
-    .startsWith(
-      'https://linkedin.com/in/',
-      'URL do perfil deve começar com https://linkedin.com/in/'
+    .refine(
+      (url) =>
+        url.startsWith('https://linkedin.com/in/') ||
+        url.startsWith('https://www.linkedin.com/in/'),
+      {
+        message:
+          'URL do perfil deve começar com https://linkedin.com/in/ ou https://www.linkedin.com/in/',
+      }
     ),
   [ProfileSchemaEnum.GitHub]: z
     .string()

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "dev": "development=true next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ./app --fix"
+    "lint": "eslint ./app --fix",
+    "test": "vitest run"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.15",

--- a/apps/web/tests/profileSchema.spec.ts
+++ b/apps/web/tests/profileSchema.spec.ts
@@ -1,0 +1,106 @@
+import {
+  ProfileSchemaEnum,
+  profileFormSchema,
+} from 'app/subscribers/profile/profileSchema'
+import { EnglishLevel } from 'global/EnglishLevel'
+import { describe, it, expect } from 'vitest'
+import { SafeParseError } from 'zod'
+
+describe('ProfileFormSchema Validation', () => {
+  it('validates a fully valid profile successfully', () => {
+    const profileData = {
+      [ProfileSchemaEnum.Name]: 'John Doe',
+      [ProfileSchemaEnum.LinkedInUrl]: 'https://linkedin.com/in/johndoe',
+      [ProfileSchemaEnum.GitHub]: 'https://github.com/johndoe',
+      [ProfileSchemaEnum.StartedWorkingAt]: new Date('2020-01-01').toString(),
+      [ProfileSchemaEnum.EnglishLevel]: EnglishLevel.Advanced,
+      [ProfileSchemaEnum.Skills]: ['JavaScript', 'React'],
+      [ProfileSchemaEnum.ReceiveEmailConfig]: ['Newsletter', 'Updates'],
+      [ProfileSchemaEnum.SkillsSuggestions]: [],
+      [ProfileSchemaEnum.SendBestOpenings]: true,
+    }
+
+    const result = profileFormSchema.safeParse(profileData)
+    expect(result.success).toBe(true)
+  })
+
+  it('allows profiles with an LinkedIn URL that starts with https://www.linkedin.com/in/', () => {
+    const invalidLinkedInURL = {
+      ...validProfileData,
+      [ProfileSchemaEnum.LinkedInUrl]: 'https://www.linkedin.com/in/johndoe',
+    }
+
+    const result = profileFormSchema.safeParse(invalidLinkedInURL)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects profiles with an invalid LinkedIn URL', () => {
+    const invalidLinkedInURL = {
+      ...validProfileData,
+      [ProfileSchemaEnum.LinkedInUrl]: 'https://example.com/in/johndoe',
+    }
+
+    const result = profileFormSchema.safeParse(invalidLinkedInURL)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const errorResult = result as SafeParseError<ProfileSchemaEnum>
+      const linkedinUrlIssue = errorResult.error.issues.find(
+        (issue) => issue.path[0] === ProfileSchemaEnum.LinkedInUrl
+      )
+
+      expect(linkedinUrlIssue).toBeDefined()
+      expect(linkedinUrlIssue?.message).toContain(
+        'URL do perfil deve começar com https://linkedin.com/in/ ou https://www.linkedin.com/in/'
+      )
+    }
+  })
+
+  it('rejects profiles with an invalid GitHub URL', () => {
+    const invalidGitHubURL = {
+      ...validProfileData,
+      [ProfileSchemaEnum.GitHub]: 'justastring',
+    }
+
+    const result = profileFormSchema.safeParse(invalidGitHubURL)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const errorResult = result as SafeParseError<ProfileSchemaEnum>
+      const gitHubIssue = errorResult.error.issues.find(
+        (issue) => issue.path[0] === ProfileSchemaEnum.GitHub
+      )
+
+      expect(gitHubIssue).toBeDefined()
+      expect(gitHubIssue?.message).toContain('Formato de URL inválido.')
+    }
+  })
+
+  it('accepts null or empty string for GitHub field', () => {
+    const profileWithNullGitHub = {
+      ...validProfileData,
+      [ProfileSchemaEnum.GitHub]: null,
+    }
+
+    const profileWithEmptyGitHub = {
+      ...validProfileData,
+      [ProfileSchemaEnum.GitHub]: '',
+    }
+
+    const resultNull = profileFormSchema.safeParse(profileWithNullGitHub)
+    const resultEmpty = profileFormSchema.safeParse(profileWithEmptyGitHub)
+
+    expect(resultNull.success).toBe(true)
+    expect(resultEmpty.success).toBe(true)
+  })
+
+  const validProfileData = {
+    [ProfileSchemaEnum.Name]: 'John Doe',
+    [ProfileSchemaEnum.LinkedInUrl]: 'https://linkedin.com/in/johndoe',
+    [ProfileSchemaEnum.GitHub]: 'https://github.com/johndoe',
+    [ProfileSchemaEnum.StartedWorkingAt]: new Date('2020-01-01').toString(),
+    [ProfileSchemaEnum.EnglishLevel]: EnglishLevel.Advanced,
+    [ProfileSchemaEnum.Skills]: ['JavaScript', 'React'],
+    [ProfileSchemaEnum.ReceiveEmailConfig]: ['Newsletter', 'Updates'],
+    [ProfileSchemaEnum.SkillsSuggestions]: [],
+    [ProfileSchemaEnum.SendBestOpenings]: true,
+  }
+})


### PR DESCRIPTION
- Changed the `profileSchema` to accept both https://linkedin.com/in and https://www.linkedin.com/in/
- Added test cases for this file that didn't existed before.
- Added a additional test case for this case in specific, making sure that the www is allowed to be inserted in the field.
- Inserted the `test` script on the web app, now it's running on concurrency with the other apps