### PR TITLE
disable NextJS image optimization

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -9,6 +9,7 @@ const nextConfig = {
         hostname: 'picsum.photos',
       },
     ],
+    unoptimized: true,
   },
   experimental: {
     serverActions: true,


### PR DESCRIPTION
It doesn't work on production, it keeps complaining about `sharp` even though it is installed so we'll just disabled.

Prod logs:

<img width="1724" alt="image" src="https://github.com/user-attachments/assets/65c1f971-08ee-4127-81c3-7b626e4121a8">
