### PR TITLE
Correção de links de vagas não funcionar no safari/IOS

### DIFF
--- a/apps/web/app/components/ui/JobCard.tsx
+++ b/apps/web/app/components/ui/JobCard.tsx
@@ -22,7 +22,7 @@ const JobCard = ({ job, skillsFromProps }) => {
     a.setAttribute('href', linkUrl); 
     a.setAttribute('target', '_blank'); 
     a.click();
-  });
+  }, []);
 
   const handleClick = useCallback(
     (event) => {

--- a/apps/web/app/components/ui/JobCard.tsx
+++ b/apps/web/app/components/ui/JobCard.tsx
@@ -17,6 +17,13 @@ const JobCard = ({ job, skillsFromProps }) => {
     return ''
   }, [job.salary])
 
+  const handleRedirect = useCallback((linkUrl: string) => {
+    const a = document.createElement("a"); 
+    a.setAttribute('href', linkUrl); 
+    a.setAttribute('target', '_blank'); 
+    a.click();
+  });
+
   const handleClick = useCallback(
     (event) => {
       event.preventDefault()
@@ -26,14 +33,14 @@ const JobCard = ({ job, skillsFromProps }) => {
           const linkUrl = shouldRedirectToUrl(job.description)
             ? job.url
             : `/vaga/${job.id}`
-          window.open(linkUrl, '_blank')
+          handleRedirect(linkUrl);
         })
         .catch((error) => {
           console.error('Erro ao contabilizar clique:', error)
           const linkUrl = shouldRedirectToUrl(job.description)
             ? job.url
             : `/vaga/${job.id}`
-          window.open(linkUrl, '_blank')
+          handleRedirect(linkUrl);
         })
     },
     [job.id, job.description, job.url]


### PR DESCRIPTION
Olá a todos,

No safari de IOS os links dos cards de vagas não está funcionando, ao clicar no card o usuário não está sendo redirecionado ao link da vaga.

O card em si não está utilizando o "href" normalmente, mas sim um redirecionamento ao link, utilizando o window.open, que possui inúmeros reports web afora, que não funciona corretamente nas novas versões do Safari.

Como proposta de solução, ao invés de utilizar o window.open, é criado um elemento temporário de link, forçando o click no mesmo, para realizar o redirect.

Testado no safari do IOS e funcionou normalmente

Desde já, muito obrigado.

Parabéns pela iniciativa do projeto 