### PR TITLE
Hotfix: Alguns links de vagas não funcionam no Safari do Ipad

### DIFF
--- a/apps/web/app/components/ui/JobCard.tsx
+++ b/apps/web/app/components/ui/JobCard.tsx
@@ -22,7 +22,7 @@ const JobCard = ({ job, skillsFromProps }) => {
     a.setAttribute('href', linkUrl); 
     a.setAttribute('target', '_blank'); 
     a.click();
-  });
+  }, []);
 
   const handleClick = useCallback(
     (event) => {

--- a/apps/web/app/components/ui/JobCard.tsx
+++ b/apps/web/app/components/ui/JobCard.tsx
@@ -17,6 +17,13 @@ const JobCard = ({ job, skillsFromProps }) => {
     return ''
   }, [job.salary])
 
+  const handleRedirect = useCallback((linkUrl: string) => {
+    const a = document.createElement("a"); 
+    a.setAttribute('href', linkUrl); 
+    a.setAttribute('target', '_blank'); 
+    a.click();
+  });
+
   const handleClick = useCallback(
     (event) => {
       event.preventDefault()
@@ -26,14 +33,14 @@ const JobCard = ({ job, skillsFromProps }) => {
           const linkUrl = shouldRedirectToUrl(job.description)
             ? job.url
             : `/vaga/${job.id}`
-          window.open(linkUrl, '_blank')
+          handleRedirect(linkUrl);
         })
         .catch((error) => {
           console.error('Erro ao contabilizar clique:', error)
           const linkUrl = shouldRedirectToUrl(job.description)
             ? job.url
             : `/vaga/${job.id}`
-          window.open(linkUrl, '_blank')
+          handleRedirect(linkUrl);
         })
     },
     [job.id, job.description, job.url]

--- a/apps/web/app/components/ui/JobCard.tsx
+++ b/apps/web/app/components/ui/JobCard.tsx
@@ -18,10 +18,12 @@ const JobCard = ({ job, skillsFromProps }) => {
   }, [job.salary])
 
   const handleRedirect = useCallback((linkUrl: string) => {
-    const a = document.createElement("a"); 
-    a.setAttribute('href', linkUrl); 
-    a.setAttribute('target', '_blank'); 
-    a.click();
+    setTimeout(() => {
+      const a = document.createElement("a"); 
+      a.setAttribute('href', linkUrl); 
+      a.setAttribute('target', '_blank'); 
+      a.click();
+    })
   }, []);
 
   const handleClick = useCallback(


### PR DESCRIPTION
Olá a todos,

Anteriormente havia feito um pull request sobre uma correção de links de vagas não funcionarem corretamente no Safari do Iphone. O pull request resolveu o problema no Iphone, mas aparentemente no Ipad o problema ainda persiste.

[PR anterior](https://github.com/ocodista/trampar-de-casa/pull/333)

Ao investigar o problema, encontrei inúmeros relatos que além da substituição do "window.open", também deve ser feito um tratamento para a abertura de links que são feitos dentro de chamadas assíncronas, como por exemplo: Dentro de um fetch, que é o caso do card de vagas, onde o link é aberto dentro de um fetch.

Existe evidências de outras pessoas no stack overflow com o mesmo problema/solução:

[Evidência](https://stackoverflow.com/a/70463940)

Também gerei reproduções dentro do codepen, emulando um link sendo aberto dentro de um fetch:

Com o bug no IOS:

[Com bug](https://codepen.io/WillRy/pen/wBwGNJP)

Sem bug no IOS:

[Sem bug](https://codepen.io/WillRy/pen/JoPXwpw)

Ao colocar a abertura do link dentro de um setTimeout, o safari não bloqueia as operações de abertura de links, há pouca explicação disponível na internet sobre a causa do problema, mas acredito ser algo relacionado a callback queue.

Caso tenha algum dispositivo com o Safari, vai conseguir ver na prática o problema nos links do codepen que enviei

Fiz os testes em Iphone e Ipad, nas versões que estou utilizando funcionou, mas seria interessante um teste com mais alguém que tem dispositivos IOS (o que é difícil achar em abundância, devido ao custo nada barato huehuehue)


Desde já, muito obrigado


